### PR TITLE
feat: add support for comment injection language

### DIFF
--- a/languages/haxe/injections.scm
+++ b/languages/haxe/injections.scm
@@ -26,3 +26,6 @@
 (comment
   (block_comment) @injection.content
   (#set! injection.language "jsdoc"))
+
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/languages/hxml/injections.scm
+++ b/languages/hxml/injections.scm
@@ -1,2 +1,5 @@
 ((haxe_expression) @injection.content
     (#set! injection.language "haxe"))
+
+((comment) @injection.content
+  (#set! injection.language "comment"))


### PR DESCRIPTION
This change allows special highlighting for comments that start with TODO, FIXME, etc when the comment language extension is installed.