### PR TITLE
add outline.scm for Outline Panel support

### DIFF
--- a/languages/haxe/outline.scm
+++ b/languages/haxe/outline.scm
@@ -1,0 +1,97 @@
+; ─── Type declarations ─────────────────────────────────────────────────────
+
+(ClassType
+  [
+    "public"
+    "private"
+    "abstract"
+    "extern"
+    "final"
+  ]* @context
+  "class" @context
+  name: (type_name) @name) @item
+
+(ClassType
+  [
+    "public"
+    "private"
+    "abstract"
+    "extern"
+    "final"
+  ]* @context
+  "interface" @context
+  name: (type_name) @name) @item
+
+(AbstractType
+  [
+    "public"
+    "private"
+    "enum"
+  ]* @context
+  "abstract" @context
+  name: (type_name) @name) @item
+
+(DefType
+  [
+    "public"
+    "private"
+    "extern"
+  ]* @context
+  "typedef" @context
+  name: (type_name) @name) @item
+
+(EnumType
+  [
+    "public"
+    "private"
+    "extern"
+  ]* @context
+  "enum" @context
+  name: (type_name) @name) @item
+
+; ─── Class body members ────────────────────────────────────────────────────
+
+; `macro` is a modifier on a `function` declaration, not a separate keyword —
+; one rule covers both regular and macro methods.
+(ClassMethod
+  [
+    "public"
+    "private"
+    "static"
+    "override"
+    "inline"
+    "dynamic"
+    "final"
+    "macro"
+  ]* @context
+  "function" @context
+  name: (identifier) @name
+  "(" @context
+  ")" @context) @item
+
+(ClassVar
+  [
+    "public"
+    "private"
+    "static"
+    "inline"
+    "dynamic"
+  ]* @context
+  ["var" "final"] @context
+  name: (identifier) @name) @item
+
+; ─── Enum constructors (nest under parent EnumType @item) ──────────────────
+
+(EnumConstructor
+  name: (identifier) @name) @item
+
+; ─── Annotations attach to the following outline item ─────────────────────
+; Metadata (@:native(...), @:noCompletion, etc.) and doc/line comments are
+; surfaced to the Assistant for edit-step generation.
+
+(MetaDataEntry) @annotation
+
+[
+  (line_comment)
+  (block_comment)
+] @annotation


### PR DESCRIPTION
Noticed that there wasn't proper outline support, so nothing shows up in the outline panel! Added `outline.scm` file with the little queries there. 

Before: 

<img width="2842" height="1730" alt="image" src="https://github.com/user-attachments/assets/3711e985-8930-4cd5-a6fc-eaa11e8360a1" />

After: 

<img width="2592" height="1782" alt="image" src="https://github.com/user-attachments/assets/b40d07e6-5da0-40cc-8b71-c37e81277d21" />
